### PR TITLE
Added custom lat/lon column name option

### DIFF
--- a/src/TrackMapPanel.tsx
+++ b/src/TrackMapPanel.tsx
@@ -39,12 +39,26 @@ export const TrackMapPanel: React.FC<Props> = ({ options, data, width, height })
   }, []);
 
   let latitudes: number[] | undefined = data.series
-    .find((f) => f.name === 'latitude' || f.name === 'lat')
+    .find(
+      (f) =>
+        f.name === 'latitude' ||
+        f.name === 'lat' ||
+        (options.coordinates.customLatitudeColumnName !== ''
+          ? f.name === options.coordinates.customLatitudeColumnName
+          : false)
+    )
     ?.fields.find((f) => f.name === 'Value')
     ?.values?.toArray();
 
   let longitudes: number[] | undefined = data.series
-    .find((f) => f.name === 'longitude' || f.name === 'lon')
+    .find(
+      (f) =>
+        f.name === 'longitude' ||
+        f.name === 'lon' ||
+        (options.coordinates.customLongitudeColumnName !== ''
+          ? f.name === options.coordinates.customLongitudeColumnName
+          : false)
+    )
     ?.fields.find((f) => f.name === 'Value')
     ?.values?.toArray();
 
@@ -64,11 +78,29 @@ export const TrackMapPanel: React.FC<Props> = ({ options, data, width, height })
     ?.values?.toArray();
 
   if (!latitudes && data.series?.length) {
-    latitudes = data.series[0].fields.find((f) => f.name === 'latitude' || f.name === 'lat')?.values.toArray();
+    latitudes = data.series[0].fields
+      .find(
+        (f) =>
+          f.name === 'latitude' ||
+          f.name === 'lat' ||
+          (options.coordinates.customLatitudeColumnName !== ''
+            ? f.name === options.coordinates.customLatitudeColumnName
+            : false)
+      )
+      ?.values.toArray();
   }
 
   if (!longitudes && data.series?.length) {
-    longitudes = data.series[0].fields.find((f) => f.name === 'longitude' || f.name === 'lon')?.values.toArray();
+    longitudes = data.series[0].fields
+      .find(
+        (f) =>
+          f.name === 'longitude' ||
+          f.name === 'lon' ||
+          (options.coordinates.customLongitudeColumnName !== ''
+            ? f.name === options.coordinates.customLongitudeColumnName
+            : false)
+      )
+      ?.values.toArray();
   }
 
   if (!intensities && data.series?.length) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,6 +5,16 @@ import { TrackMapOptions } from './types';
 export const plugin = new PanelPlugin<TrackMapOptions>(TrackMapPanel).setPanelOptions((builder) => {
   return (
     builder
+      .addTextInput({
+        path: 'coordinates.customLatitudeColumnName',
+        name: 'Custom latitude column name',
+        defaultValue: '',
+      })
+      .addTextInput({
+        path: 'coordinates.customLongitudeColumnName',
+        name: 'Custom latitude column name',
+        defaultValue: '',
+      })
       .addBooleanSwitch({
         path: 'discardZeroOrNull',
         name: 'Discard positions that contains null (avoid plugin crash) or exactly 0 (inconsistent) coordinates.',
@@ -52,7 +62,7 @@ export const plugin = new PanelPlugin<TrackMapOptions>(TrackMapPanel).setPanelOp
       .addTextInput({
         path: 'map.tileUrlSchema',
         name: 'Custom map tiles URL schema',
-        defaultValue: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+        defaultValue: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
       })
       .addBooleanSwitch({
         path: 'map.useBoundsInQuery',

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface TrackMapOptions {
   map: Map;
   viewType: ViewType;
   ant: AntOptions;
+  coordinates: CoordinateOptions;
   heat: HeatOptions;
   marker: MarkerOptions;
   hex: HexOptions;
@@ -20,6 +21,11 @@ interface Map {
   useCenterFromFirstPos: boolean;
   useCenterFromLastPos: boolean;
   tileUrlSchema: string;
+}
+
+interface CoordinateOptions {
+  customLatitudeColumnName: string;
+  customLongitudeColumnName: string;
 }
 
 interface AntOptions {


### PR DESCRIPTION
Closes #56 as it is now possible to set a custom column name as source for latitude or longitude. 

![image](https://user-images.githubusercontent.com/6787349/116537832-07667900-a8e7-11eb-8130-e796811f7cfc.png)
